### PR TITLE
Add simple asset portfolio page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { AssetProvider } from "@/context/AssetContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <AssetProvider>{children}</AssetProvider>
       </body>
     </html>
   );

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+import { useState } from 'react';
+import { useAssets } from '@/context/AssetContext';
+
+export default function PortfolioPage() {
+  const { balances, deposit, withdraw } = useAssets();
+  const [asset, setAsset] = useState('BTC');
+  const [amount, setAmount] = useState(0);
+
+  const handleDeposit = () => {
+    if (amount > 0) deposit(asset, amount);
+  };
+
+  const handleWithdraw = () => {
+    if (amount > 0) withdraw(asset, amount);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Portfolio</h1>
+      <ul>
+        {Object.entries(balances).map(([key, value]) => (
+          <li key={key} className="my-1">
+            {key}: {value}
+          </li>
+        ))}
+      </ul>
+      <div className="flex flex-col space-y-2 max-w-xs">
+        <select
+          value={asset}
+          onChange={(e) => setAsset(e.target.value)}
+          className="border p-1"
+        >
+          {Object.keys(balances).map((a) => (
+            <option key={a}>{a}</option>
+          ))}
+        </select>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(Number(e.target.value))}
+          className="border p-1"
+        />
+        <div className="flex space-x-2">
+          <button onClick={handleDeposit} className="bg-green-500 text-white px-2 py-1">
+            Deposit
+          </button>
+          <button onClick={handleWithdraw} className="bg-red-500 text-white px-2 py-1">
+            Withdraw
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/context/AssetContext.tsx
+++ b/src/context/AssetContext.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect, useContext } from 'react';
+
+export type Balances = Record<string, number>;
+
+type AssetContextType = {
+  balances: Balances;
+  deposit: (asset: string, amount: number) => void;
+  withdraw: (asset: string, amount: number) => void;
+};
+
+const AssetContext = React.createContext<AssetContextType | undefined>(undefined);
+
+const STORAGE_KEY = 'asset-balances';
+
+export const AssetProvider = ({ children }: { children: React.ReactNode }) => {
+  const [balances, setBalances] = useState<Balances>({ BTC: 0, USD: 0 });
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        setBalances(JSON.parse(stored));
+      } catch {
+        // ignore parsing errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(balances));
+  }, [balances]);
+
+  const deposit = (asset: string, amount: number) => {
+    setBalances((prev) => ({ ...prev, [asset]: (prev[asset] || 0) + amount }));
+  };
+
+  const withdraw = (asset: string, amount: number) => {
+    setBalances((prev) => ({ ...prev, [asset]: (prev[asset] || 0) - amount }));
+  };
+
+  return (
+    <AssetContext.Provider value={{ balances, deposit, withdraw }}>
+      {children}
+    </AssetContext.Provider>
+  );
+};
+
+export const useAssets = () => {
+  const ctx = useContext(AssetContext);
+  if (!ctx) throw new Error('useAssets must be used within AssetProvider');
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- add AssetContext for balance management
- wrap layout with AssetProvider
- create a Portfolio page for managing balances

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684819f68ef4832a9d6e84ab53978694