### PR TITLE
Fix AssetContext build issue

### DIFF
--- a/src/context/AssetContext.tsx
+++ b/src/context/AssetContext.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useState, useEffect, useContext } from 'react';
 
 export type Balances = Record<string, number>;


### PR DESCRIPTION
## Summary
- mark AssetContext as a client component

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481ae9b910832a8e1efbf1a0f2a7a1